### PR TITLE
Tests for basic igo_common functions

### DIFF
--- a/src/igo.c
+++ b/src/igo.c
@@ -8,6 +8,10 @@ int igo_init (
     /* --- inouts --- */
     igo_common* igo_cm
 ) {
+    if (igo_cm == NULL) {
+        return 0;
+    }
+
     igo_cm->cholmod_cm = malloc(sizeof(cholmod_common));
     cholmod_start(igo_cm->cholmod_cm);
 
@@ -44,6 +48,9 @@ int igo_finish (
     /* --- inouts --- */
     igo_common* igo_cm
 ) {
+    if (igo_cm == NULL) {
+        return 1;
+    }
     igo_free_sparse(&(igo_cm->A), igo_cm);
     igo_free_dense(&(igo_cm->b), igo_cm);
     igo_free_factor(&(igo_cm->L), igo_cm);

--- a/src/igo.h
+++ b/src/igo.h
@@ -109,7 +109,7 @@ int igo_init (
     igo_common* igo_cm
 ) ;
 
-/* Always succeeds (returning 1). Attempting to finish a NULL pointer performs no operation on it instead. */
+/* Always succeeds and returns 1. Attempting to finish a NULL pointer performs no operation on it instead. */
 int igo_finish (
     /* --- inouts --- */
     igo_common* igo_cm

--- a/src/igo.h
+++ b/src/igo.h
@@ -103,11 +103,13 @@ typedef struct igo_common_struct {
 /* Primary functions */
 /* ---------------------------------------------------------- */
 
+/* Returns 0 if given a NULL pointer, 1 otherwise. */
 int igo_init (
     /* --- inouts --- */
     igo_common* igo_cm
 ) ;
 
+/* Always succeeds (returning 1). Attempting to finish a NULL pointer performs no operation on it instead. */
 int igo_finish (
     /* --- inouts --- */
     igo_common* igo_cm

--- a/tests/test_igo_common.cpp
+++ b/tests/test_igo_common.cpp
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+
+extern "C" {
+#include <igo.h>
+}
+
+TEST(CommonTests, TestInitTypical) {
+    igo_common* igo_cm = (igo_common*) malloc(sizeof(igo_common));
+    int ret = igo_init(igo_cm);
+    ASSERT_EQ(ret, 1);
+    ASSERT_NE(igo_cm, (void*)NULL);
+    // check cholmod initialization
+    ASSERT_NE(igo_cm->cholmod_cm, (void*)NULL);
+    ASSERT_EQ(igo_cm->cholmod_cm->status, 0);
+    // check matrices
+    ASSERT_NE(igo_cm->A, (void*)NULL);
+    ASSERT_NE(igo_cm->b, (void*)NULL);
+    ASSERT_NE(igo_cm->L, (void*)NULL);
+    ASSERT_NE(igo_cm->PAb, (void*)NULL);
+    ASSERT_NE(igo_cm->x, (void*)NULL);
+    ASSERT_NE(igo_cm->y, (void*)NULL);
+    // cleanup
+    cholmod_free_sparse(&igo_cm->A->A, igo_cm->cholmod_cm);
+    cholmod_free_dense(&igo_cm->b->B, igo_cm->cholmod_cm);
+    cholmod_free_factor(&igo_cm->L->L, igo_cm->cholmod_cm);
+    cholmod_free_dense(&igo_cm->PAb->B, igo_cm->cholmod_cm);
+    cholmod_free_dense(&igo_cm->x->B, igo_cm->cholmod_cm);
+    cholmod_free_dense(&igo_cm->y->B, igo_cm->cholmod_cm);
+    free(igo_cm->A);
+    free(igo_cm->b);
+    free(igo_cm->L);
+    free(igo_cm->PAb);
+    free(igo_cm->x);
+    free(igo_cm->y);
+    cholmod_finish(igo_cm->cholmod_cm);
+    free(igo_cm);
+}
+
+TEST(CommonTests, TestFinishTypical) {
+    igo_common* igo_cm = (igo_common*) malloc(sizeof(igo_common));
+    igo_init(igo_cm);
+    int ret = igo_finish(igo_cm);
+    ASSERT_EQ(ret, 1);
+    ASSERT_EQ(igo_cm->cholmod_cm, (void*)NULL);
+    free(igo_cm);
+}
+
+TEST(CommonTests, TestFinishNull) {
+    igo_common* igo_cm = NULL;
+    int ret = igo_finish(igo_cm);
+    ASSERT_EQ(ret, 0);
+}
+
+TEST(CommonTests, TestInitNull) {
+    igo_common* igo_cm = NULL;
+    int ret = igo_init(igo_cm);
+    ASSERT_EQ(ret, 0);
+}

--- a/tests/test_igo_common.cpp
+++ b/tests/test_igo_common.cpp
@@ -16,20 +16,17 @@ TEST(CommonTests, TestInitTypical) {
     ASSERT_NE(igo_cm->A, (void*)NULL);
     ASSERT_NE(igo_cm->b, (void*)NULL);
     ASSERT_NE(igo_cm->L, (void*)NULL);
-    ASSERT_NE(igo_cm->PAb, (void*)NULL);
     ASSERT_NE(igo_cm->x, (void*)NULL);
     ASSERT_NE(igo_cm->y, (void*)NULL);
     // cleanup
     cholmod_free_sparse(&igo_cm->A->A, igo_cm->cholmod_cm);
     cholmod_free_dense(&igo_cm->b->B, igo_cm->cholmod_cm);
     cholmod_free_factor(&igo_cm->L->L, igo_cm->cholmod_cm);
-    cholmod_free_dense(&igo_cm->PAb->B, igo_cm->cholmod_cm);
     cholmod_free_dense(&igo_cm->x->B, igo_cm->cholmod_cm);
     cholmod_free_dense(&igo_cm->y->B, igo_cm->cholmod_cm);
     free(igo_cm->A);
     free(igo_cm->b);
     free(igo_cm->L);
-    free(igo_cm->PAb);
     free(igo_cm->x);
     free(igo_cm->y);
     cholmod_finish(igo_cm->cholmod_cm);
@@ -48,7 +45,7 @@ TEST(CommonTests, TestFinishTypical) {
 TEST(CommonTests, TestFinishNull) {
     igo_common* igo_cm = NULL;
     int ret = igo_finish(igo_cm);
-    ASSERT_EQ(ret, 0);
+    ASSERT_EQ(ret, 1);
 }
 
 TEST(CommonTests, TestInitNull) {


### PR DESCRIPTION
Adds tests for igo_init() and igo_finish().
Updates igo_init and igo_finish to check for NULL pointers and return appropriate values instead of crashing.